### PR TITLE
Rewrite to use `fetch` & avoid `URL.createObjectURL`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,20 @@
-import * as L from 'leaflet';
+import * as L from "leaflet";
 
-
-declare module 'leaflet' {
+declare module "leaflet" {
     namespace TileLayer {
         export class WMSHeader extends WMS {
             constructor(
                 baseUrl: string,
                 options: WMSOptions,
-                header: {header: string, value: string}[],
+                header: { header: string; value: string }[],
                 abort: Promise<void>
             );
         }
-    }
-    namespace tileLayer {
+
         export function wmsHeader(
             baseUrl: string,
             options: WMSOptions,
-            header: {header: string, value: string}[],
-            abort: Promise<void>
+            header: { header: string; value: string }[]
         ): WMSHeader;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,7 @@ declare module 'leaflet' {
             constructor(
                 baseUrl: string,
                 options: WMSOptions,
-                header: { header: string; value: string }[],
-                abort: Promise<void>
+                header: { header: string; value: string }[]
             );
         }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-import * as L from "leaflet";
+import * as L from 'leaflet';
 
-declare module "leaflet" {
+declare module 'leaflet' {
     namespace TileLayer {
         export class WMSHeader extends WMS {
             constructor(

--- a/index.js
+++ b/index.js
@@ -1,48 +1,45 @@
-'use strict';
+// import L from "leaflet";
 
-function callAjax(url, callback, headers, abort) {
-  var xmlhttp;
-  xmlhttp = new XMLHttpRequest();
-  xmlhttp.responseType = 'blob';
-  xmlhttp.onreadystatechange = () => {
-    if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
-      callback(xmlhttp.response);
-    }
-  }
-  xmlhttp.open("GET", url, true);
-  for (const h of headers) {
-    xmlhttp.setRequestHeader(h.header, h.value)
-  }
-  if (abort) {
-    var sub = abort.then(() => {
-      xmlhttp.abort();
-    });
-  }
-  xmlhttp.send();
+async function fetchImage(url, callback, headers) {
+  let _headers = {};
+  headers.forEach(h => {
+    _headers[h.header] = h.value;
+  });
+  const f = await fetch(url, {
+    method: "GET",
+    headers: _headers,
+    mode: "cors"
+  });
+  const blob = await f.blob();
+  callback(blob);
 }
 
 L.TileLayer.WMSHeader = L.TileLayer.WMS.extend({
-  initialize: function (url, options, headers, abort) {
+  initialize: function (url, options, headers) {
     L.TileLayer.WMS.prototype.initialize.call(this, url, options);
     this.headers = headers;
-    this.abort = abort;
   },
   createTile(coords, done) {
     const url = this.getTileUrl(coords);
-    const img = document.createElement('img');
-    callAjax(
+    const img = document.createElement("img");
+    img.setAttribute("role", "presentation");
+
+    fetchImage(
       url,
-      (response) => {
-        img.src = URL.createObjectURL(response);
+      resp => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          img.src = reader.result;
+        };
+        reader.readAsDataURL(resp);
         done(null, img);
       },
-      this.headers,
-      this.abort
-    )
+      this.headers
+    );
     return img;
   }
 });
 
-L.tileLayer.wmsHeader = function (url, options, headers, abort) {
+L.TileLayer.wmsHeader = function (url, options, headers, abort) {
   return new L.TileLayer.WMSHeader(url, options, headers, abort);
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // import L from "leaflet";
+'use strict';
 
 async function fetchImage(url, callback, headers) {
   let _headers = {};


### PR DESCRIPTION
Thanks for a great plugin!

It didn't work out of the box in our ReactJS / TypeScript application, so we changed to use `fetch` and avoid `URL.createObjectURL` as the browser doesn't seem to support that.

Using Leaflet version 1.5.1.

The use case for us is to add an authorization header for WMS layers with security.

What is your use case?