### PR TITLE
fix "Cannot use namespace" error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as L from 'leaflet';
-import Observable from 'rxjs';
+import {Observable} from 'rxjs';
 
 declare module 'leaflet' {
   namespace TileLayer {
@@ -8,14 +8,14 @@ declare module 'leaflet' {
         baseUrl: string,
         options: WMSOptions,
         header: { header: string; value: string }[],
-        abort: Observable
+        abort: Observable<any>
       );
     }
     export function wmsHeader(
       baseUrl: string,
       options: WMSOptions,
       header: { header: string; value: string }[],
-      abort: Observable
+      abort: Observable<any>
     ): L.TileLayer.WMSHeader;
   }
 }


### PR DESCRIPTION

![Capture](https://user-images.githubusercontent.com/9675110/74084887-e0751a80-4a88-11ea-9bbd-2d15dd42351c.PNG)
fix "Cannot use namespace 'Observable' as a type." error on typescript