### PR TITLE
Make abort parameter optional as suggested by the README #10

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,14 +8,14 @@ declare module 'leaflet' {
         baseUrl: string,
         options: WMSOptions,
         header: { header: string; value: string }[],
-        abort: Observable<any>
+        abort?: Observable<any>
       );
     }
     export function wmsHeader(
       baseUrl: string,
       options: WMSOptions,
       header: { header: string; value: string }[],
-      abort: Observable<any>
+      abort?: Observable<any>
     ): L.TileLayer.WMSHeader;
   }
 }


### PR DESCRIPTION
In case the documentation is correct about the "abort parameter" being optional, please feel free to use this PR to fix the TypeScript definition file.