### PR TITLE
Auto aborting calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "Ticinum Aerospace",
   "license": "ISC",
+  "peerDependencies": {
+    "leaflet": "^1.7.1"
+  },
   "dependencies": {
     "rxjs": "^6.5.3",
     "typescript": "^2.9.2"


### PR DESCRIPTION
WMS calls are not auto aborted after map view change. This PR resolved this issue by overwriting `_abortLoading` tile method. Quick demo how it works like: https://drive.google.com/file/d/1r1-y_ChCXKJ4-l2zqvbTBQzUn_VI4qjS/view?usp=sharing.

I've also added `leaflet` as a peer dependency.

The change is backward compatible.